### PR TITLE
Removed the forward slash that interferes with assembly with writerside.

### DIFF
--- a/Writerside/topics/highlights-and-benefits.md
+++ b/Writerside/topics/highlights-and-benefits.md
@@ -1,6 +1,6 @@
 [//]: # (title: Highlights & Benefits)
 
-![](/MATERIAL_TYPES.png)
+![](MATERIAL_TYPES.png)
 
 Pieces for Developers was built from the ground up to serve as a centralized place to save all types of materials and resources related to a developer's work-in-progress journey.
 


### PR DESCRIPTION
Writerside does not support relative paths for images, I've just removed the forward slash for image that show us an error during the building process.